### PR TITLE
Expose the information in the ImageData type.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,6 @@
     "purescript-functions": "^0.1.0",
     "purescript-maybe": "^0.3.0",
     "purescript-exceptions": "^0.3.1",
-    "purescript-arraybugger-types": "^0.2.0"
+    "purescript-arraybuffer-types": "^0.2.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "purescript-eff": "^0.1.0",
     "purescript-functions": "^0.1.0",
     "purescript-maybe": "^0.3.0",
-    "purescript-exceptions": "^0.3.1"
+    "purescript-exceptions": "^0.3.1",
+    "purescript-arraybugger-types": "^0.2.0"
   }
 }

--- a/src/Graphics/Canvas.js
+++ b/src/Graphics/Canvas.js
@@ -446,24 +446,6 @@ exports.createImageDataCopy = function(ctx) {
     };
 };
 
-exports.getImageDataWidth = function(image_data) {
-    return function() {
-        return image_data.width;
-    };
-};
-
-exports.getImageDataHeight = function(image_data) {
-    return function() {
-        return image_data.height;
-    };
-};
-
-exports.getImageDataPixelArray = function(image_data) {
-    return function() {
-        return image_data.data;
-    };
-};
-
 exports.drawImage = function(ctx) {
     return function(image_source) {
         return function(dx) {

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -6,7 +6,6 @@ module Graphics.Canvas
   , CanvasElement()
   , Context2D()
   , ImageData()
-  , CanvasPixelArray()
   , CanvasImageSource()
   , Arc()
   , Composite(..)
@@ -82,9 +81,6 @@ module Graphics.Canvas
 
   , withImage
   , getImageData
-  , getImageDataWidth
-  , getImageDataHeight
-  , getImageDataPixelArray
   , putImageData
   , putImageDataFull
   , createImageData
@@ -106,6 +102,7 @@ module Graphics.Canvas
 
 import Prelude
 
+import Data.ArrayBuffer.Types
 import Data.Function
 import Data.Maybe
 import Control.Monad.Eff
@@ -121,10 +118,7 @@ foreign import data CanvasElement :: *
 foreign import data Context2D :: *
 
 -- | An image data object, used to store raster data outside the canvas.
-foreign import data ImageData :: *
-
--- | An array of pixel data.
-foreign import data CanvasPixelArray :: *
+type ImageData = { width :: Number, height :: Number, data :: Uint8ClampedArray }
 
 -- | Opaque object for drawing elements and things to the canvas.
 foreign import data CanvasImageSource :: *
@@ -462,7 +456,7 @@ foreign import getImageData :: forall eff. Context2D -> Number -> Number -> Numb
 -- | Set image data for a portion of the canvas.
 foreign import putImageDataFull :: forall eff. Context2D -> ImageData -> Number -> Number -> Number -> Number -> Number -> Number -> Eff (canvas :: Canvas | eff) Context2D
 
--- | Get image data for a portion of the canvas.
+-- | Set image data for a portion of the canvas.
 foreign import putImageData :: forall eff. Context2D -> ImageData -> Number -> Number -> Eff (canvas :: Canvas | eff) Context2D
 
 -- | Create an image data object.
@@ -470,15 +464,6 @@ foreign import createImageData :: forall eff. Context2D -> Number -> Number -> E
 
 -- | Create a copy of an image data object.
 foreign import createImageDataCopy :: forall eff. Context2D -> ImageData -> Eff (canvas :: Canvas | eff) ImageData
-
--- | Get the width of an image data object in pixels.
-foreign import getImageDataWidth :: forall eff. ImageData -> Eff (canvas :: Canvas | eff) Number
-
--- | Get the height of an image data object in pixels.
-foreign import getImageDataHeight :: forall eff. ImageData -> Eff (canvas :: Canvas | eff) Number
-
--- | Get the pixel data array from an image data object.
-foreign import getImageDataPixelArray :: forall eff. ImageData -> Eff (canvas :: Canvas | eff) CanvasPixelArray
 
 foreign import drawImage :: forall eff. Context2D -> CanvasImageSource -> Number -> Number -> Eff (canvas :: Canvas | eff) Context2D
 

--- a/src/Graphics/Canvas.purs
+++ b/src/Graphics/Canvas.purs
@@ -118,7 +118,7 @@ foreign import data CanvasElement :: *
 foreign import data Context2D :: *
 
 -- | An image data object, used to store raster data outside the canvas.
-type ImageData = { width :: Number, height :: Number, data :: Uint8ClampedArray }
+type ImageData = { width :: Int, height :: Int, data :: Uint8ClampedArray }
 
 -- | Opaque object for drawing elements and things to the canvas.
 foreign import data CanvasImageSource :: *


### PR DESCRIPTION
- Getting width and height of an ImageData are not effecting.
- The pixel information is availalbe as a Uint8ClampedArray.

This is my first contribution to a purescript module in public use, so let me know if I've done something wrong. In particular, I've removed some signatures that could be backwards-compatibly implemented, but would perhaps be confusing in the future. I don't know how this community thinks about changing contracts in releases so I am happy to put them back.